### PR TITLE
refactor(workitem): centralize open import

### DIFF
--- a/src/commands/workitem.ts
+++ b/src/commands/workitem.ts
@@ -3,6 +3,7 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import ora from 'ora';
 import Table from 'cli-table3';
+import open from 'open';
 import { ConfigManager } from '../config';
 import { AdoApiClient } from '../api/client';
 import { AuthManager } from '../auth';
@@ -398,7 +399,6 @@ async function createWorkItem(configManager: ConfigManager, options: any): Promi
     console.log(`🔗 URL: ${workItem._links.html.href}`);
     
     if (options.web) {
-      const open = require('open');
       await open(workItem._links.html.href);
     }
   } catch (error) {
@@ -477,7 +477,6 @@ async function viewWorkItem(configManager: ConfigManager, id: number): Promise<v
       console.log(`📝 Title: ${workItem.fields['System.Title']}`);
       console.log(`🔗 URL: ${chalk.blue(webUrl)}`);
       
-      const open = require('open');
       await open(webUrl);
     } else {
       throw new Error('Work item URL not available');


### PR DESCRIPTION
## Summary
- refactor workitem command to use top-level `open` import
- remove redundant `require('open')` calls when creating or viewing work items

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended" to extend from)*
- `npm run build`
- `node -e "const open=require('open');open('https://example.com').then(()=>console.log('opened')).catch(err=>console.error('open failed:',err.message));"`


------
https://chatgpt.com/codex/tasks/task_e_68a8cb58f9e88326b92136d5df024c99