### PR TITLE
feat: add pull request CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ The CLI uses Azure DevOps Personal Access Tokens (PAT) for authentication:
 - `ado workitem close <id>` - Close a work item
 - `ado workitem reopen <id>` - Reopen a work item
 
+### Pull Requests
+- `ado pr list --repository <repo>` - List pull requests
+- `ado pr view <id> --repository <repo>` - View a pull request
+- `ado pr create --repository <repo> --source <branch> --target <branch> --title "My PR"` - Create a pull request
+
 #### Work Item Listing Options
 ```bash
 ado workitem list --assignee @me          # Items assigned to you
@@ -150,6 +155,15 @@ ado workitem close 123 --comment "Fixed in latest deployment"
 
 # Work with a different project temporarily
 ado workitem list -R myorg/otherproject --state Active
+
+# List pull requests in a repository
+ado pr list --repository MyRepo
+
+# View a pull request
+ado pr view 42 --repository MyRepo
+
+# Create a pull request
+ado pr create --repository MyRepo --source feature --target main --title "Add feature"
 ```
 
 ## Development

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { ConfigManager } from '../config';
-import { WorkItem, WorkItemType, CreateWorkItemRequest, WorkItemUpdateRequest, AdoApiResponse } from '../types';
+import { WorkItem, WorkItemType, CreateWorkItemRequest, WorkItemUpdateRequest, AdoApiResponse, PullRequest, CreatePullRequestRequest } from '../types';
 
 export class AdoApiClient {
   private client: AxiosInstance;
@@ -206,12 +206,60 @@ export class AdoApiClient {
   async deleteWorkItem(id: number): Promise<void> {
     const baseUrl = this.getBaseUrl();
     const project = this.getProject();
-    
+
     await this.client.delete(
       `${baseUrl}/${project}/_apis/wit/workitems/${id}`,
       {
         params: { 'api-version': '7.1' }
       }
     );
+  }
+
+  // Pull Request endpoints
+
+  async getPullRequests(repositoryId: string, status: string = 'active'): Promise<PullRequest[]> {
+    const baseUrl = this.getBaseUrl();
+    const project = this.getProject();
+
+    const response = await this.client.get<AdoApiResponse<PullRequest>>(
+      `${baseUrl}/${project}/_apis/git/repositories/${encodeURIComponent(repositoryId)}/pullrequests`,
+      {
+        params: {
+          'searchCriteria.status': status,
+          'api-version': '7.1'
+        }
+      }
+    );
+
+    return response.data.value;
+  }
+
+  async getPullRequest(repositoryId: string, pullRequestId: number): Promise<PullRequest> {
+    const baseUrl = this.getBaseUrl();
+    const project = this.getProject();
+
+    const response = await this.client.get<PullRequest>(
+      `${baseUrl}/${project}/_apis/git/repositories/${encodeURIComponent(repositoryId)}/pullrequests/${pullRequestId}`,
+      {
+        params: { 'api-version': '7.1' }
+      }
+    );
+
+    return response.data;
+  }
+
+  async createPullRequest(repositoryId: string, request: CreatePullRequestRequest): Promise<PullRequest> {
+    const baseUrl = this.getBaseUrl();
+    const project = this.getProject();
+
+    const response = await this.client.post<PullRequest>(
+      `${baseUrl}/${project}/_apis/git/repositories/${encodeURIComponent(repositoryId)}/pullrequests`,
+      request,
+      {
+        params: { 'api-version': '7.1' }
+      }
+    );
+
+    return response.data;
   }
 }

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -1,0 +1,150 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import Table from 'cli-table3';
+import { ConfigManager } from '../config';
+import { AdoApiClient } from '../api/client';
+import { AuthManager } from '../auth';
+import { PullRequest, CreatePullRequestRequest } from '../types';
+
+export function createPrCommand(configManager: ConfigManager): Command {
+  const command = new Command('pr');
+  command.description('Manage pull requests');
+
+  const authManager = new AuthManager(configManager);
+
+  command
+    .command('list')
+    .description('List pull requests')
+    .requiredOption('-r, --repository <id>', 'Repository name or ID')
+    .option('-s, --status <state>', 'Filter by status (active, completed, abandoned)', 'active')
+    .option('-R, --repo <org/project>', 'Target organization/project')
+    .action(async (options) => {
+      try {
+        if (options.repo) {
+          configManager.setRepository(options.repo);
+        }
+        await authManager.ensureAuthenticated();
+        await listPullRequests(configManager, options);
+      } catch (error) {
+        console.error(chalk.red(`Error: ${error}`));
+        process.exit(1);
+      }
+    });
+
+  command
+    .command('view <id>')
+    .description('View a pull request')
+    .requiredOption('-r, --repository <id>', 'Repository name or ID')
+    .option('-R, --repo <org/project>', 'Target organization/project')
+    .action(async (id, options) => {
+      try {
+        if (options.repo) {
+          configManager.setRepository(options.repo);
+        }
+        await authManager.ensureAuthenticated();
+        await viewPullRequest(configManager, options.repository, parseInt(id));
+      } catch (error) {
+        console.error(chalk.red(`Error: ${error}`));
+        process.exit(1);
+      }
+    });
+
+  command
+    .command('create')
+    .description('Create a pull request')
+    .requiredOption('-r, --repository <id>', 'Repository name or ID')
+    .requiredOption('-s, --source <branch>', 'Source branch')
+    .requiredOption('-t, --target <branch>', 'Target branch')
+    .requiredOption('-T, --title <title>', 'Pull request title')
+    .option('-d, --description <text>', 'Pull request description')
+    .option('-R, --repo <org/project>', 'Target organization/project')
+    .action(async (options) => {
+      try {
+        if (options.repo) {
+          configManager.setRepository(options.repo);
+        }
+        await authManager.ensureAuthenticated();
+        await createPullRequest(configManager, options);
+      } catch (error) {
+        console.error(chalk.red(`Error: ${error}`));
+        process.exit(1);
+      }
+    });
+
+  return command;
+}
+
+async function listPullRequests(configManager: ConfigManager, options: any): Promise<void> {
+  const spinner = ora('Fetching pull requests...').start();
+  try {
+    const client = new AdoApiClient(configManager);
+    const prs = await client.getPullRequests(options.repository, options.status);
+    spinner.succeed(`Found ${prs.length} pull requests`);
+    if (prs.length === 0) {
+      console.log(chalk.yellow('No pull requests found.'));
+      return;
+    }
+    const table = new Table({ head: ['ID', 'Title', 'Status', 'Created By'] });
+    prs.forEach((pr: PullRequest) => {
+      table.push([
+        pr.pullRequestId,
+        truncate(pr.title),
+        pr.status,
+        pr.createdBy.displayName,
+      ]);
+    });
+    console.log(table.toString());
+  } catch (error) {
+    spinner.fail('Failed to fetch pull requests');
+    throw error;
+  }
+}
+
+async function viewPullRequest(configManager: ConfigManager, repositoryId: string, prId: number): Promise<void> {
+  const spinner = ora('Fetching pull request...').start();
+  try {
+    const client = new AdoApiClient(configManager);
+    const pr = await client.getPullRequest(repositoryId, prId);
+    spinner.stop();
+    console.log(chalk.cyan(`#${pr.pullRequestId} ${pr.title}`));
+    console.log(`Status: ${pr.status}`);
+    console.log(`Created By: ${pr.createdBy.displayName}`);
+    console.log(`Source: ${pr.sourceRefName}`);
+    console.log(`Target: ${pr.targetRefName}`);
+    if (pr.description) {
+      console.log('\n' + pr.description);
+    }
+    if (pr._links?.web?.href) {
+      console.log(`\n${chalk.dim(pr._links.web.href)}`);
+    }
+  } catch (error) {
+    spinner.fail('Failed to fetch pull request');
+    throw error;
+  }
+}
+
+async function createPullRequest(configManager: ConfigManager, options: any): Promise<void> {
+  const spinner = ora('Creating pull request...').start();
+  try {
+    const client = new AdoApiClient(configManager);
+    const request: CreatePullRequestRequest = {
+      sourceRefName: options.source.startsWith('refs/') ? options.source : `refs/heads/${options.source}`,
+      targetRefName: options.target.startsWith('refs/') ? options.target : `refs/heads/${options.target}`,
+      title: options.title,
+      description: options.description,
+    };
+    const pr = await client.createPullRequest(options.repository, request);
+    spinner.succeed(`Pull request #${pr.pullRequestId} created`);
+    if (pr._links?.web?.href) {
+      console.log(chalk.cyan(pr._links.web.href));
+    }
+  } catch (error) {
+    spinner.fail('Failed to create pull request');
+    throw error;
+  }
+}
+
+function truncate(text: string, length = 60): string {
+  return text.length > length ? `${text.substring(0, length - 3)}...` : text;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { ConfigManager } from './config';
 import { createAuthCommand } from './commands/auth';
 import { createWorkItemCommand } from './commands/workitem';
 import { createRepoCommand } from './commands/repo';
+import { createPrCommand } from './commands/pr';
 
 const program = new Command();
 const configManager = new ConfigManager();
@@ -18,6 +19,7 @@ program
 program.addCommand(createAuthCommand(configManager));
 program.addCommand(createWorkItemCommand(configManager));
 program.addCommand(createRepoCommand(configManager));
+program.addCommand(createPrCommand(configManager));
 
 program.configureHelp({
   sortSubcommands: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,3 +90,27 @@ export interface WorkItemUpdateRequest {
   value?: any;
   from?: string;
 }
+
+export interface PullRequest {
+  pullRequestId: number;
+  title: string;
+  description?: string;
+  status: string;
+  createdBy: {
+    displayName: string;
+    uniqueName: string;
+  };
+  creationDate: string;
+  sourceRefName: string;
+  targetRefName: string;
+  _links: {
+    web?: { href: string };
+  };
+}
+
+export interface CreatePullRequestRequest {
+  sourceRefName: string;
+  targetRefName: string;
+  title: string;
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- add `pr` command with list, view, and create subcommands
- extend API client with pull request endpoints
- document pull request usage in README

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68c58828cb6483268bbb581a20ea8517